### PR TITLE
Add sort button and Changed the settings storage method.

### DIFF
--- a/pixiv previewer.user.js
+++ b/pixiv previewer.user.js
@@ -3850,7 +3850,7 @@ function Load() {
         try {
             if (g_pageType == PageType.Artwork) {
                 Pages[g_pageType].Work();
-                if (g_settings.enablePreview || eventFromButton) {
+                if (g_settings.enablePreview) {
                     PixivPreview();
                 }
             }
@@ -3859,18 +3859,18 @@ function Load() {
                     g_sortComplete = false;
                     PixivSK(function () {
                         g_sortComplete = true;
-                        if (g_settings.enablePreview || eventFromButton) {
+                        if (g_settings.enablePreview) {
                             PixivPreview();
                         }
                     });
-                } else if (g_settings.enablePreview || eventFromButton) {
+                } else if (g_settings.enablePreview) {
                     PixivPreview();
                 }
             } else if (g_pageType == PageType.NovelSearch) {
                 if (g_settings.enableNovelSort || eventFromButton) {
                     PixivNS();
                 }
-            } else if (g_settings.enablePreview || eventFromButton) {
+            } else if (g_settings.enablePreview) {
                 PixivPreview();
             }
         }

--- a/pixiv previewer.user.js
+++ b/pixiv previewer.user.js
@@ -3798,8 +3798,11 @@ function Load() {
         toolBar.appendChild(newListItem);
 
         $(newButton).click(function() {
-            runPixivPreview(true);
             this.disabled = true;
+            runPixivPreview(true);
+            setTimeout(() => {
+                this.disabled = false;
+            }, 7000);
         });
     }
 


### PR DESCRIPTION

・Added a button to initiate sorting when pressed.
・Changed the settings storage location from Cookies to LocalStorage.

Hello, I am "Happy-come-come".

This pull request is intended to add a button that starts sorting when pressed and to change the settings storage location from Cookies to LocalStorage.

Firstly, regarding the former. Until now, the sorting feature of this script was automatically executed every time the page was refreshed, provided the sorting function was enabled. However, this meant that the script would unnecessarily make API requests whenever users wanted to switch categories (e.g., All, Illustrations, Manga, etc.) or change the age restrictions of images (e.g., All Ages, R-18). To address this, I added a button on the page (above the script's settings button) that allows sorting to be performed even when the sorting feature is not turned on.

Regarding the latter, the script's settings were previously stored in cookies. However, storing data in cookies leads to unnecessary data transmission to the server during communication. Browsers offer a LocalStorage API, which allows for persistent data storage, and I have utilized this to store the settings.

Additionally, when adding the settings button, the script was cloning a \<li> within a \<ul> but then replacing it with a button using outerHTML. I have modified this to add a button within the \<li> instead.

I have tried to adhere to the code style and variable naming conventions used in this script as much as possible. If there are any concerns or suggestions for improvement, please let me know.

Thank you.
