### PR TITLE
Feature detection for passive event does not work anymore

### DIFF
--- a/pixiv previewer.user.js
+++ b/pixiv previewer.user.js
@@ -1623,16 +1623,9 @@ function CheckUrlTest() {
 function preventDefault(e) {
     e.preventDefault();
 }
-// modern Chrome requires { passive: false } when adding event
-var supportsPassive = false;
-try {
-    window.addEventListener("test", null, Object.defineProperty({}, 'passive', {
-        get: function () { supportsPassive = true; }
-    }));
-} catch (e) { }
 
-var wheelOpt = supportsPassive ? { passive: false } : false;
-var wheelEvent = 'onwheel' in document.createElement('div') ? 'wheel' : 'mousewheel';
+const wheelOpt = { passive: false };
+const wheelEvent = 'onwheel' in document.createElement('div') ? 'wheel' : 'mousewheel';
 
 function disableScroll() {
     window.addEventListener(wheelEvent, preventDefault, wheelOpt);


### PR DESCRIPTION
No idea if this issue is coming from Chrome, Tampermonkey v5.0.0, or other dependency. Initializing 'wheelOpt' without checking should be just fine, nobody uses IE anymore.